### PR TITLE
Create Exception class for package

### DIFF
--- a/src/Dfcplc/PostcodeAnywhere/BankValidation/Validate.php
+++ b/src/Dfcplc/PostcodeAnywhere/BankValidation/Validate.php
@@ -1,6 +1,8 @@
 <?php
 namespace Dfcplc\PostcodeAnywhere\BankValidation;
 
+use Dfcplc\PostcodeAnywhere\Exception;
+
 class Validate
 {
 

--- a/src/Dfcplc/PostcodeAnywhere/Exception.php
+++ b/src/Dfcplc/PostcodeAnywhere/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Dfcplc\PostcodeAnywhere;
+
+class Exception extends \Exception
+{
+}

--- a/src/Dfcplc/PostcodeAnywhere/InternationalBankValidation/Validate.php
+++ b/src/Dfcplc/PostcodeAnywhere/InternationalBankValidation/Validate.php
@@ -1,6 +1,8 @@
 <?php
 namespace Dfcplc\PostcodeAnywhere\InternationalBankValidation;
 
+use Dfcplc\PostcodeAnywhere\Exception;
+
 class Validate
 {
 
@@ -28,7 +30,7 @@ class Validate
 		//Check for an error, if there is one then throw an exception
 		if ($file->Columns->Column->attributes()->Name == "Error")
 		{
-			throw new \Exception("[ID] " . $file->Rows->Row->attributes()->Error . " [DESCRIPTION] " . $file->Rows->Row->attributes()->Description . " [CAUSE] " . $file->Rows->Row->attributes()->Cause . " [RESOLUTION] " . $file->Rows->Row->attributes()->Resolution);
+			throw new Exception("[ID] " . $file->Rows->Row->attributes()->Error . " [DESCRIPTION] " . $file->Rows->Row->attributes()->Description . " [CAUSE] " . $file->Rows->Row->attributes()->Cause . " [RESOLUTION] " . $file->Rows->Row->attributes()->Resolution);
 		}
 
 		//Copy the data

--- a/src/Dfcplc/PostcodeAnywhere/PostcodeAnywhere/Find.php
+++ b/src/Dfcplc/PostcodeAnywhere/PostcodeAnywhere/Find.php
@@ -1,6 +1,8 @@
 <?php
 namespace Dfcplc\PostcodeAnywhere\PostcodeAnywhere;
 
+use Dfcplc\PostcodeAnywhere\Exception;
+
 class Lookup
 {
 	private $Key; //The key to use to authenticate to the service.
@@ -43,7 +45,7 @@ class Lookup
 		//Check for an error, if there is one then throw an exception
 		if ($file->Columns->Column->attributes()->Name == "Error")
 		{
-			throw new \Exception("[ID] " . $file->Rows->Row->attributes()->Error . " [DESCRIPTION] " . $file->Rows->Row->attributes()->Description . " [CAUSE] " . $file->Rows->Row->attributes()->Cause . " [RESOLUTION] " . $file->Rows->Row->attributes()->Resolution);
+			throw new Exception("[ID] " . $file->Rows->Row->attributes()->Error . " [DESCRIPTION] " . $file->Rows->Row->attributes()->Description . " [CAUSE] " . $file->Rows->Row->attributes()->Cause . " [RESOLUTION] " . $file->Rows->Row->attributes()->Resolution);
 		}
 
 		//Copy the data

--- a/src/Dfcplc/PostcodeAnywhere/PostcodeAnywhere/FindByParts.php
+++ b/src/Dfcplc/PostcodeAnywhere/PostcodeAnywhere/FindByParts.php
@@ -1,6 +1,8 @@
 <?php
 namespace Dfcplc\PostcodeAnywhere\PostcodeAnywhere;
 
+use Dfcplc\PostcodeAnywhere\Exception;
+
 class FindByParts
 {
 	//Credit: Thanks to Stuart Sillitoe (http://stu.so/me) for the original PHP that these samples are based on.
@@ -42,7 +44,7 @@ class FindByParts
 		//Check for an error, if there is one then throw an exception
 		if ($file->Columns->Column->attributes()->Name == "Error")
 		{
-			throw new \Exception("[ID] " . $file->Rows->Row->attributes()->Error . " [DESCRIPTION] " . $file->Rows->Row->attributes()->Description . " [CAUSE] " . $file->Rows->Row->attributes()->Cause . " [RESOLUTION] " . $file->Rows->Row->attributes()->Resolution);
+			throw new Exception("[ID] " . $file->Rows->Row->attributes()->Error . " [DESCRIPTION] " . $file->Rows->Row->attributes()->Description . " [CAUSE] " . $file->Rows->Row->attributes()->Cause . " [RESOLUTION] " . $file->Rows->Row->attributes()->Resolution);
 		}
 
 		//Copy the data

--- a/src/Dfcplc/PostcodeAnywhere/PostcodeAnywhere/Retrieve.php
+++ b/src/Dfcplc/PostcodeAnywhere/PostcodeAnywhere/Retrieve.php
@@ -1,6 +1,8 @@
 <?php
 namespace Dfcplc\PostcodeAnywhere\PostcodeAnywhere;
 
+use Dfcplc\PostcodeAnywhere\Exception;
+
 class Retrieve
 {
 	//Credit: Thanks to Stuart Sillitoe (http://stu.so/me) for the original PHP that these samples are based on.
@@ -27,7 +29,7 @@ class Retrieve
 		//Check for an error, if there is one then throw an exception
 		if ($file->Columns->Column->attributes()->Name == "Error")
 		{
-			throw new \Exception("[ID] " . $file->Rows->Row->attributes()->Error . " [DESCRIPTION] " . $file->Rows->Row->attributes()->Description . " [CAUSE] " . $file->Rows->Row->attributes()->Cause . " [RESOLUTION] " . $file->Rows->Row->attributes()->Resolution);
+			throw new Exception("[ID] " . $file->Rows->Row->attributes()->Error . " [DESCRIPTION] " . $file->Rows->Row->attributes()->Description . " [CAUSE] " . $file->Rows->Row->attributes()->Cause . " [RESOLUTION] " . $file->Rows->Row->attributes()->Resolution);
 		}
 
 		//Copy the data


### PR DESCRIPTION
- This also fixes a missing '\' before Exception in the BankValidation
  class, which resulted in a class not found error
